### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Stauros
 
 A fast XSS sanitation library for PHP.
 
-##IMPORTANT
+## IMPORTANT
 
 # **THIS IS AN EXPERIMENTAL LIBRARY, USE AT YOUR OWN RISK**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
